### PR TITLE
Remove unused Algolia searchParameters config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -181,10 +181,6 @@ module.exports = {
             indexName: 'junglesequencer',
             contextualSearch: true,
             searchPagePath: 'search',
-            searchParameters: {
-                clickAnalytics: false,
-                facetFilters: ['type:docs'],
-            },
         },
         
         prism: {


### PR DESCRIPTION
Deleted the searchParameters object from the Algolia configuration in docusaurus.config.js as it is no longer needed.