### PR TITLE
Update custom inspector example to use IdentityNode

### DIFF
--- a/versioned_docs/version-1.0.x/guides/custom-node-inspectors.mdx
+++ b/versioned_docs/version-1.0.x/guides/custom-node-inspectors.mdx
@@ -46,8 +46,8 @@ No custom inspector **(Red)** _Vs._ custom inspector **(Green)**:
 
 ### Example
 
-Here's an example of a custom inspector for a node that inherits from `GenericNode`. This inspector displays a property
-field for the `value` property.
+Here's an example of a custom inspector for a node that inherits from `IdentityNode`. 
+This inspector displays a property field for the `value` property.
 
 The #if UNITY_EDITOR tag ensures that the editor code is stripped from the build.
 


### PR DESCRIPTION
Replaces the reference to GenericNode with IdentityNode in the custom inspector example for clarity and accuracy.