### PR TITLE
Update docs version label and path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,8 +24,8 @@ module.exports = {
                     editUrl: 'https://github.com/Jacked-Up/junglesequencer.com/blob/live/',
                     versions: {
                         current: {
-                            label: '🚧 Work in Progress',
-                            path: 'wip' 
+                            label: '2.0.x (WIP 🚧)',
+                            path: '2.0.x' 
                         }
                     },
                     sidebarCollapsible: true,


### PR DESCRIPTION
Changed the current docs version label to '2.0.x (WIP 🚧)' and updated its path to '2.0.x' for improved clarity and consistency.