### PR TITLE
Update docs version label to '2.0.x (Unreleased)'

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = {
                     editUrl: 'https://github.com/Jacked-Up/junglesequencer.com/blob/live/',
                     versions: {
                         current: {
-                            label: '2.0.x (WIP 🚧)',
+                            label: '2.0.x (Unreleased)',
                             path: '2.0.x' 
                         }
                     },


### PR DESCRIPTION
Changed the documentation version label from '2.0.x (WIP 🚧)' to '2.0.x (Unreleased)' for clarity.